### PR TITLE
Fix reading '0' and empty chunks

### DIFF
--- a/bin/run.php
+++ b/bin/run.php
@@ -69,7 +69,7 @@ class Builder
         
         $out = $process->getStderr();
         
-        while ($buffer = yield $out->read()) {
+        while (null !== $buffer = yield $out->read()) {
             echo $buffer;
         }
         


### PR DESCRIPTION
Reading a `"0"` or empty chunk previously ended the stream reading loop.